### PR TITLE
Fix duplication of libGL

### DIFF
--- a/docker/generic/Dockerfile.cuda
+++ b/docker/generic/Dockerfile.cuda
@@ -72,14 +72,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 COPY --from=nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04 \
   /usr/local/lib/x86_64-linux-gnu \
-  /usr/local/lib/x86_64-linux-gnu
+  /usr/lib/x86_64-linux-gnu
 COPY --from=nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04 \
   /usr/local/share/glvnd/egl_vendor.d/10_nvidia.json \
   /usr/local/share/glvnd/egl_vendor.d/10_nvidia.json
 RUN echo '/usr/local/lib/x86_64-linux-gnu' >> /etc/ld.so.conf.d/glvnd.conf && \
     ldconfig && \
-    echo '/usr/local/$LIB/libGL.so.1' >> /etc/ld.so.preload && \
-    echo '/usr/local/$LIB/libEGL.so.1' >> /etc/ld.so.preload
+    echo '/usr/$LIB/libGL.so.1' >> /etc/ld.so.preload && \
+    echo '/usr/$LIB/libEGL.so.1' >> /etc/ld.so.preload
 RUN apt update
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES \


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
libGL was available in _/usr/lib/x86_64-linux-gnu_ and _/usr/local/lib/x86_64-linux-gnu_ which turned into compiler warnings of type:
_Cannot generate a safe runtime search path for target X because files
  in some directories may conflict with libraries in implicit directories:_